### PR TITLE
Carry over optimiser state in update() methods

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -134,7 +134,7 @@ function  fit!(chain, optimiser, loss, epochs,
         verbosity != 1 || next!(meter)
 
     end
-    
+
     return Flux.cpu(chain), history
 
 end

--- a/src/core.jl
+++ b/src/core.jl
@@ -1,6 +1,6 @@
 ## EXPOSE OPTIMISERS TO MLJ (for eg, tuning)
 
-# Here we: (i) Make the optimiser structs "transarent" so that their
+# Here we: (i) Make the optimiser structs "transparent" so that their
 # field values are exposed by calls to MLJ.params; and (ii) Overload
 # `==` for optimisers, so that we can detect when their parameters
 # remain unchanged on calls to MLJModelInterface.update methods.

--- a/test/classifier.jl
+++ b/test/classifier.jl
@@ -57,6 +57,14 @@ losses = []
     push!(losses, first_last_training_loss[2])
     yhat = MLJBase.predict(mach, rows=test);
     @test mean(MLJBase.cross_entropy(yhat, y[test])) < 0.95*loss_baseline
+
+    optimisertest(MLJFlux.NeuralNetworkClassifier,
+                  X,
+                  y,
+                  builder,
+                  optimiser,
+                  accel)
+
 end
 
 # check different resources (CPU1, CUDALibs, etc)) give about the same loss:

--- a/test/image.jl
+++ b/test/image.jl
@@ -53,6 +53,9 @@ losses = []
     @test basictest(MLJFlux.ImageClassifier, images, labels,
                            model.builder, model.optimiser, 0.95, accel)
 
+    @test optimisertest(MLJFlux.ImageClassifier, images, labels,
+                           model.builder, model.optimiser, accel)
+
 end
 
 # check different resources (CPU1, CUDALibs, etc)) give about the same loss:
@@ -152,6 +155,9 @@ losses = []
                                     batch_size=2,
                                     acceleration=accel)
     fitresult, cache, _report = MLJBase.fit(model, 0, images, labels);
+
+    @test optimisertest(MLJFlux.ImageClassifier, images, labels,
+                           model.builder, model.optimiser, accel)
 
 end
 

--- a/test/image.jl
+++ b/test/image.jl
@@ -139,7 +139,7 @@ losses = []
     # tests update logic, etc (see test_utililites.jl):
     @test basictest(MLJFlux.ImageClassifier, images, labels,
                            model.builder, model.optimiser, 0.95, accel)
-    
+
     @time fitresult, cache, _report = MLJBase.fit(model, 0, images, labels)
     pred = MLJBase.predict(model, fitresult, images[1:6])
     first_last_training_loss = _report[1][[1, end]]

--- a/test/regressor.jl
+++ b/test/regressor.jl
@@ -42,7 +42,7 @@ end
 
 # check different resources (CPU1, CUDALibs, etc)) give about the same loss:
 reference = losses[1]
-@test all(x->abs(x - reference)/reference < 1e-4, losses[2:end])
+@test_broken all(x->abs(x - reference)/reference < 1e-4, losses[2:end])
 
 Random.seed!(123)
 ymatrix = hcat(1 .+ X.x1 - X.x2, 1 .- 2X.x4 + X.x5);
@@ -78,6 +78,6 @@ end
 
 # check different resources (CPU1, CUDALibs, etc)) give about the same loss:
 reference = losses[1]
-@test all(x->abs(x - reference)/reference < 1e-4, losses[2:end])
+@test_broken all(x->abs(x - reference)/reference < 1e-4, losses[2:end])
 
 true

--- a/test/regressor.jl
+++ b/test/regressor.jl
@@ -42,7 +42,8 @@ end
 
 # check different resources (CPU1, CUDALibs, etc)) give about the same loss:
 reference = losses[1]
-@test_broken all(x->abs(x - reference)/reference < 1e-4, losses[2:end])
+#@test all(x->abs(x - reference)/reference < 1e-4, losses[2:end])
+@show [abs(x - reference)/reference for loss in  losses[2:end]]
 
 Random.seed!(123)
 ymatrix = hcat(1 .+ X.x1 - X.x2, 1 .- 2X.x4 + X.x5);
@@ -78,6 +79,7 @@ end
 
 # check different resources (CPU1, CUDALibs, etc)) give about the same loss:
 reference = losses[1]
-@test_broken all(x->abs(x - reference)/reference < 1e-4, losses[2:end])
+#@test all(x->abs(x - reference)/reference < 1e-4, losses[2:end])
+@show [abs(x - reference)/reference for loss in  losses[2:end]]
 
 true

--- a/test/regressor.jl
+++ b/test/regressor.jl
@@ -78,6 +78,6 @@ end
 
 # check different resources (CPU1, CUDALibs, etc)) give about the same loss:
 reference = losses[1]
-@test all(x->abs(x - reference)/reference < 1e-6, losses[2:end])
+@test all(x->abs(x - reference)/reference < 1e-5, losses[2:end])
 
 true

--- a/test/regressor.jl
+++ b/test/regressor.jl
@@ -43,7 +43,7 @@ end
 # check different resources (CPU1, CUDALibs, etc)) give about the same loss:
 reference = losses[1]
 #@test all(x->abs(x - reference)/reference < 1e-4, losses[2:end])
-@show [abs(x - reference)/reference for loss in  losses[2:end]]
+@show [abs(x - reference)/reference for x in  losses[2:end]]
 
 Random.seed!(123)
 ymatrix = hcat(1 .+ X.x1 - X.x2, 1 .- 2X.x4 + X.x5);
@@ -80,6 +80,6 @@ end
 # check different resources (CPU1, CUDALibs, etc)) give about the same loss:
 reference = losses[1]
 #@test all(x->abs(x - reference)/reference < 1e-4, losses[2:end])
-@show [abs(x - reference)/reference for loss in  losses[2:end]]
+@show [abs(x - reference)/reference for x in  losses[2:end]]
 
 true

--- a/test/regressor.jl
+++ b/test/regressor.jl
@@ -42,7 +42,7 @@ end
 
 # check different resources (CPU1, CUDALibs, etc)) give about the same loss:
 reference = losses[1]
-@test all(x->abs(x - reference)/reference < 1e-5, losses[2:end])
+@test all(x->abs(x - reference)/reference < 1e-4, losses[2:end])
 
 Random.seed!(123)
 ymatrix = hcat(1 .+ X.x1 - X.x2, 1 .- 2X.x4 + X.x5);
@@ -78,6 +78,6 @@ end
 
 # check different resources (CPU1, CUDALibs, etc)) give about the same loss:
 reference = losses[1]
-@test all(x->abs(x - reference)/reference < 1e-5, losses[2:end])
+@test all(x->abs(x - reference)/reference < 1e-4, losses[2:end])
 
 true

--- a/test/regressor.jl
+++ b/test/regressor.jl
@@ -17,7 +17,7 @@ train, test = MLJBase.partition(1:N, 0.7)
 @testset_accelerated "NeuralNetworkRegressor" accel begin
 
     Random.seed!(123)
-    
+
     basictest(MLJFlux.NeuralNetworkRegressor,
               X,
               y,
@@ -53,7 +53,7 @@ losses = []
 @testset_accelerated "MultitargetNeuralNetworkRegressor" accel begin
 
     Random.seed!(123)
-    
+
     basictest(MLJFlux.MultitargetNeuralNetworkRegressor,
               X,
               y,

--- a/test/regressor.jl
+++ b/test/regressor.jl
@@ -42,7 +42,7 @@ end
 
 # check different resources (CPU1, CUDALibs, etc)) give about the same loss:
 reference = losses[1]
-@test all(x->abs(x - reference)/reference < 1e-6, losses[2:end])
+@test all(x->abs(x - reference)/reference < 1e-5, losses[2:end])
 
 Random.seed!(123)
 ymatrix = hcat(1 .+ X.x1 - X.x2, 1 .- 2X.x4 + X.x5);

--- a/test/regressor.jl
+++ b/test/regressor.jl
@@ -42,8 +42,7 @@ end
 
 # check different resources (CPU1, CUDALibs, etc)) give about the same loss:
 reference = losses[1]
-#@test all(x->abs(x - reference)/reference < 1e-4, losses[2:end])
-@show [abs(x - reference)/reference for x in  losses[2:end]]
+@test all(x->abs(x - reference)/reference < 1e-6, losses[2:end])
 
 Random.seed!(123)
 ymatrix = hcat(1 .+ X.x1 - X.x2, 1 .- 2X.x4 + X.x5);
@@ -79,7 +78,6 @@ end
 
 # check different resources (CPU1, CUDALibs, etc)) give about the same loss:
 reference = losses[1]
-#@test all(x->abs(x - reference)/reference < 1e-4, losses[2:end])
-@show [abs(x - reference)/reference for x in  losses[2:end]]
+@test all(x->abs(x - reference)/reference < 1e-6, losses[2:end])
 
 true

--- a/test/regressor.jl
+++ b/test/regressor.jl
@@ -38,6 +38,14 @@ train, test = MLJBase.partition(1:N, 0.7)
     truth = y[test]
     goal = 0.9*model.loss(truth .- mean(truth), 0)
     @test model.loss(yhat, truth) < goal
+
+    optimisertest(MLJFlux.NeuralNetworkRegressor,
+                  X,
+                  y,
+                  builder,
+                  optimiser,
+                  accel)
+
 end
 
 # check different resources (CPU1, CUDALibs, etc)) give about the same loss:
@@ -69,11 +77,19 @@ losses = []
         fit(model, 0, MLJBase.selectrows(X, train), selectrows(y, train))
     first_last_training_loss = rpt[1][[1, end]]
     push!(losses, first_last_training_loss[2])
-#    @show first_last_training_loss
+#   @show first_last_training_loss
     yhat = predict(model, fitresult, selectrows(X, test))
     truth = ymatrix[test]
     goal = 0.9*model.loss(truth .- mean(truth), 0)
     @test model.loss(Tables.matrix(yhat), truth) < goal
+
+    optimisertest(MLJFlux.MultitargetNeuralNetworkRegressor,
+              X,
+              y,
+              builder,
+              optimiser,
+              accel)
+
 end
 
 # check different resources (CPU1, CUDALibs, etc)) give about the same loss:

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -135,21 +135,23 @@ function optimisertest(ModelType, X, y, builder, optimiser, accel)
              mach = machine(model, $X, $y);
 
              # two epochs in stages:
-             Random.seed!(123)
-             #seed!($accel_ex)
+             Random.seed!(123) # chains are always initialized on CPU
              fit!(mach, verbosity=0, force=true);
-             @show mach.cache[end]
              model.epochs = model.epochs + 1
              fit!(mach, verbosity=0); # update
              l1 = MLJBase.report(mach).training_losses[end]
 
              # two epochs in one go:
-             Random.seed!(123)
-             #seed!($accel_ex)
+             Random.seed!(123) # chains are always initialized on CPU
              fit!(mach, verbosity=1, force=true)
              l2 = MLJBase.report(mach).training_losses[end]
 
-             @test isapprox(l1, l2)
+             if accel isa CPU1
+                 @test isapprox(l1, l2)
+             else
+                 @test_broken isapprox(l1, l2, rtol=1e-8)
+             end
+
          end)
 
     return true

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -111,25 +111,25 @@ function basictest(ModelType, X, y, builder, optimiser, threshold, accel)
                     MLJBase.update(model, 2, fitresult, cache, $X, $y));
 
          # optimiser "state" is preserved in update
-         if $accel_ex isa CPU1
-             model.epochs = 1
-             mach = machine(model, $X, $y);
+         # if $accel_ex isa CPU1
+         #     model.epochs = 1
+         #     mach = machine(model, $X, $y);
 
-             # two epochs in stages:
-             Random.seed!(123)
-             fit!(mach, verbosity=0, force=true);
-             model.epochs = model.epochs + 1
-             fit!(mach, verbosity=0);
-             l1 = MLJBase.report(mach).training_losses[end]
+         #     # two epochs in stages:
+         #     Random.seed!(123)
+         #     fit!(mach, verbosity=0, force=true);
+         #     model.epochs = model.epochs + 1
+         #     fit!(mach, verbosity=0);
+         #     l1 = MLJBase.report(mach).training_losses[end]
 
-             # two epochs in one go:
-             Random.seed!(123)
-             fit!(mach, verbosity=1, force=true)
-             l2 = MLJBase.report(mach).training_losses[end]
+         #     # two epochs in one go:
+         #     Random.seed!(123)
+         #     fit!(mach, verbosity=1, force=true)
+         #     l2 = MLJBase.report(mach).training_losses[end]
 
-             @test l1 ≈ l2
-         end
-         end)
+         #     @test l1 ≈ l2
+         # end
+;         end)
 
     return true
 end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -135,14 +135,16 @@ function optimisertest(ModelType, X, y, builder, optimiser, accel)
              mach = machine(model, $X, $y);
 
              # two epochs in stages:
-             seed!($accel_ex)
+             Random.seed!(123)
+             #seed!($accel_ex)
              fit!(mach, verbosity=0, force=true);
              model.epochs = model.epochs + 1
              fit!(mach, verbosity=0);
              l1 = MLJBase.report(mach).training_losses[end]
 
              # two epochs in one go:
-             seed!($accel_ex)
+             Random.seed!(123)
+             #seed!($accel_ex)
              fit!(mach, verbosity=1, force=true)
              l2 = MLJBase.report(mach).training_losses[end]
 

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -138,8 +138,9 @@ function optimisertest(ModelType, X, y, builder, optimiser, accel)
              Random.seed!(123)
              #seed!($accel_ex)
              fit!(mach, verbosity=0, force=true);
+             @show mach.cache[end]
              model.epochs = model.epochs + 1
-             fit!(mach, verbosity=0);
+             fit!(mach, verbosity=0); # update
              l1 = MLJBase.report(mach).training_losses[end]
 
              # two epochs in one go:


### PR DESCRIPTION
This PR corrects an issue whereby optimiser "state" (eg, the momentum) is not carried over in a warm-restart. For example, the following test (added in this PR) now passes:

```julia
            using MLJBase, MLJFlux
            X, y = make_regression()
            model = NeuralNetworkRegressor() 
            
             model.epochs = 1
             mach = machine(model, $X, $y);

             # two epochs in stages:
             Random.seed!(123)
             fit!(mach, verbosity=0);
             model.epochs = model.epochs + 1
             fit!(mach, verbosity=0);
             l1 = MLJBase.report(mach).training_losses[end]

             # two epochs in one go:
             Random.seed!(123)
             fit!(mach, verbosity=1, force=true)
             l2 = MLJBase.report(mach).training_losses[end]

             @test l1 ≈ l2
```