### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+examples/* linguist-documentation
+old_examples/* linguist-documentation


### PR DESCRIPTION
Adding notebooks generally messes up github's [linguist](https://github.com/github/linguist/) and shows incorrect language statistics, which isn't very good from a search engine optimization point of view. One way to get around this is to create a special [.gitattributes file that ignores selective files while running linguist](https://github.com/github/linguist/blob/master/docs/overrides.md).

I've seen this in various repositories that contain paper/notebooks as a part of the main repo. Might be a good idea to add this to most MLJ projects.