### PR TITLE
Fix predict functions of models using BatchNorm

### DIFF
--- a/src/classifier.jl
+++ b/src/classifier.jl
@@ -80,7 +80,7 @@ function MLJModelInterface.predict(model::NeuralNetworkClassifier,
                                    Xnew_)
     chain, levels = fitresult
     Xnew = MLJModelInterface.matrix(Xnew_)
-    probs = vcat([chain(Xnew[i, :])' for i in 1:size(Xnew, 1)]...)
+    probs = vcat([chain(tomat(Xnew[i, :]))' for i in 1:size(Xnew, 1)]...)
     return MLJModelInterface.UnivariateFinite(levels, probs)
 end
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -276,6 +276,14 @@ function reformat(X, ::Type{<:AbstractVector{<:ColorImage}})
 end
 
 # ------------------------------------------------------------
+# Reformatting vectors of lengthh n into matrices of dimension n * 1
+# This enables compatibility with Flux's BatchNorm.
+
+function tomat end
+tomat(x::Matrix) = x
+tomat(x::Vector) = reshape(x, size(x, 1), 1)
+
+# ------------------------------------------------------------
 # Reformatting vectors of "scalar" types
 
 reformat(y, ::Type{<:AbstractVector{<:Continuous}}) = y

--- a/src/regressor.jl
+++ b/src/regressor.jl
@@ -188,12 +188,12 @@ function MLJModelInterface.predict(model::Regressor, fitresult, Xnew_)
     Xnew_ = MLJModelInterface.matrix(Xnew_)
 
     if target_is_multivariate
-        ypred = [chain(values.(Xnew_[i, :]))
+        ypred = [chain(values.(tomat(Xnew_[i, :])))
                  for i in 1:size(Xnew_, 1)]
         return MLJModelInterface.table(reduce(hcat, y for y in ypred)',
                                        names=target_column_names)
     else
-        return [chain(values.(Xnew_[i, :]))[1]
+        return [chain(values.(tomat(Xnew_[i, :])))[1]
                 for i in 1:size(Xnew_, 1)]
     end
 end


### PR DESCRIPTION
This PR solves #142.

The BatchNorm layers (and perhaps other non-standard Flux layers) do not accept vector-shape data. Instead, they require matrices.
However, during prediction, the predict function of both NeuralNetworkClassifier and NeuralNetworkRegressor send data sample by sample to the network, in the form of vectors, causing an error.

The fix consists in reshaping the vector of length n into a matrix of shape n * 1.