### PR TITLE
Automate creation of new builders with @build

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,8 +275,14 @@ MLJ provides two simple builders out of the box. In all cases weights
 
 See Table 1 above to see how `n_in` and `n_out` relate to the data.
 
-Alternatively, `MLJFlux.@builder(neural_net)` automatically creates a builder
-for any valid `neural_net`, e.g. `MLJFlux.@builder(Dense(n_in, n_out, tanh))`.
+Alternatively, use `MLJFlux.@builder(neural_net)` to automatically create a builder for
+any valid Flux chain expression `neural_net`, where the symbols `n_in`, `n_out`,
+`n_channels` and `rng` can appear literally, with the interpretations explained above. For
+example,
+
+```
+builder = MLJFlux.@builder Chain(Dense(n_in, 128), Dense(128, n_out, tanh))
+```
 
 
 ### Model hyperparameters.

--- a/README.md
+++ b/README.md
@@ -275,6 +275,9 @@ MLJ provides two simple builders out of the box. In all cases weights
 
 See Table 1 above to see how `n_in` and `n_out` relate to the data.
 
+Alternatively, `MLJFlux.@build(neural_net)` automatically creates a builder
+for any valid `neural_net`, e.g. `MLJFlux.@build(Dense(100, 2, tanh))`.
+
 
 ### Model hyperparameters.
 
@@ -378,6 +381,7 @@ following conditions:
 - The object returned by `chain(x)` must be an `AbstractFloat` vector
   of length `n_out`.
 
+See also `MLJFlux.@build` for an automated way to create new builders.
 
 ### Loss functions
 

--- a/README.md
+++ b/README.md
@@ -275,8 +275,8 @@ MLJ provides two simple builders out of the box. In all cases weights
 
 See Table 1 above to see how `n_in` and `n_out` relate to the data.
 
-Alternatively, `MLJFlux.@build(neural_net)` automatically creates a builder
-for any valid `neural_net`, e.g. `MLJFlux.@build(Dense(100, 2, tanh))`.
+Alternatively, `MLJFlux.@builder(neural_net)` automatically creates a builder
+for any valid `neural_net`, e.g. `MLJFlux.@builder(Dense(n_in, n_out, tanh))`.
 
 
 ### Model hyperparameters.
@@ -381,7 +381,7 @@ following conditions:
 - The object returned by `chain(x)` must be an `AbstractFloat` vector
   of length `n_out`.
 
-See also `MLJFlux.@build` for an automated way to create new builders.
+See also `MLJFlux.@builder` for an automated way to create generic builders.
 
 ### Loss functions
 

--- a/src/builders.jl
+++ b/src/builders.jl
@@ -61,3 +61,24 @@ function build(builder::Short, rng, n, m)
         Flux.Dropout(builder.dropout),
         Flux.Dense(n_hidden, m, init=init))
 end
+
+"""
+    @build neural_net
+
+Creates a builder for `neural_net`.
+
+# Examples
+```jldoctest
+julia> nn = NeuralNetworkRegressor(builder = @build(Chain(Dense(784, 64, relu),
+                                                          Dense(64, 32, relu),
+                                                          Dense(32, 10))));
+```
+"""
+macro build(nn)
+    name = gensym()
+    quote
+        struct $name <: MLJFlux.Builder end
+        MLJFlux.build(::$name, ::Any, ::Any, ::Any) = $nn
+        $name()
+    end
+end


### PR DESCRIPTION
When prototyping, I would prefer not to have to write explicitly a new builder for any architecture I want to try.