### PR TITLE
Improve one-hot encoding performance 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
+    env:
+      PYTHON: ""
     strategy:
       fail-fast: false
       matrix:

--- a/src/core.jl
+++ b/src/core.jl
@@ -219,15 +219,11 @@ tomat(y::Vector) = reshape(y, size(y, 1), 1)
 # ------------------------------------------------------------
 # Reformatting vectors of "scalar" types
 
-reformat(y, ::Type{<:AbstractVector{<:Continuous}}) = reshape(y, 1, length(y))
+reformat(y, ::Type{<:AbstractVector{<:Union{Continuous,Count}}}) =
+    reshape(y, 1, length(y))
 function reformat(y, ::Type{<:AbstractVector{<:Finite}})
     levels = y |> first |> MLJModelInterface.classes
-    return hcat([Flux.onehot(ele, levels) for ele in y]...,)
-end
-
-function reformat(y, ::Type{<:AbstractVector{<:Count}})
-    levels = y |> first |> MLJModelInterface.classes
-    return hcat([Flux.onehot(ele, levels) for ele in y]...,)
+    return Flux.onehotbatch(y, levels)
 end
 
 _get(Xmatrix::AbstractMatrix, b) = Xmatrix[:, b]


### PR DESCRIPTION
Addresses #185. 

I'm getting a  20x improvement on the example posted there:

```julia
using MLJ

# N=1850786
N = 10^4
y = rand([0,1], N);
x1 = Float32.(y .+ 1)
df =(y = y,
    x1 = x1,
    x2 = x1,
    x3 = x1,
    x4 = x1);

y, X = unpack(df, ==(:y), !=(:y); :y=>Multiclass{2});

CLS = @load NeuralNetworkClassifier
nnc = CLS(epochs = 1)

mach = machine(nnc, X, y)
fit!(mach)

julia> @time fit!(mach, force=true)
[ Info: Training Machine{NeuralNetworkClassifier{Short,…},…} @508.
  2.072888 seconds (5.53 M allocations: 1.805 GiB, 8.77% gc time, 2.36% compilation time)
```

Also, no StackOverflow in case of N=1850786

