### PR TITLE
fix MLP

### DIFF
--- a/src/builders.jl
+++ b/src/builders.jl
@@ -83,7 +83,7 @@ MLP(; hidden=(100,), σ=Flux.relu) = MLP(hidden, σ)
 function MLJFlux.build(mlp::MLP, rng, n_in, n_out)
     init=Flux.glorot_uniform(rng)
 
-    hidden = [Flux.Dense(n_in, mlp.hidden[1], mlp.σ, init=init)]
+    hidden = Any[Flux.Dense(n_in, mlp.hidden[1], mlp.σ, init=init)]
     for i ∈ 2:length(mlp.hidden)
         push!(hidden, Flux.Dense(mlp.hidden[i-1],
                                  mlp.hidden[i],

--- a/test/builders.jl
+++ b/test/builders.jl
@@ -76,3 +76,11 @@ end
     ps4 = Flux.params(chain4)
     @test size.(ps4) == [(3, 3, 2, 16), (16,), (3, 144), (3,)]
 end
+
+@testset_accelerated "MLP" accel begin
+    builder = MLJFlux.MLP(hidden = (2, 2))
+    rng = StableRNGs.StableRNG(123)
+    nn = MLJFlux.build(builder, rng, 3, 3)
+    @test length(nn.layers) == 3
+    @test size(nn.layers[1].weight) == (2, 3)
+end


### PR DESCRIPTION
Otherwise there is the following error
```julia
julia> MLJFlux.build(builder, rng, 3, 3)
ERROR: MethodError: Cannot `convert` an object of type 
  Flux.Dense{typeof(identity),Array{Float32{},2},Array{Float32{},1}} to an object of type 
  Flux.Dense{typeof(NNlib.relu),Array{Float32{},2},Array{Float32{},1}}
Closest candidates are:
  convert(::Type{T}, ::T) where T at essentials.jl:205
Stacktrace:
 [1] push!(a::Vector{Flux.Dense{typeof(NNlib.relu), Matrix{Float32}, Vector{Float32}}}, item::Flux.Dense{typeof(identity), Matrix{Float32}, Vector{Float32}})
   @ Base ./array.jl:932
 [2] build(mlp::MLJFlux.MLP{3}, rng::Random._GLOBAL_RNG, n_in::Int64, n_out::Int64)
   @ MLJFlux ~/.julia/dev/MLJFlux/src/builders.jl:93
 [3] top-level scope
   @ REPL[9]:1
 [4] top-level scope
   @ ~/.julia/packages/CUDA/YpW0k/src/initialization.jl:52
```