### PR TITLE
Dispatch fit! and train! on model for greater extensibility

### DIFF
--- a/src/MLJFlux.jl
+++ b/src/MLJFlux.jl
@@ -19,10 +19,10 @@ include("utilities.jl")
 const MMI=MLJModelInterface
 
 include("penalizers.jl")
-include("core.jl")
 include("builders.jl")
 include("metalhead.jl")
 include("types.jl")
+include("core.jl")
 include("regressor.jl")
 include("classifier.jl")
 include("image.jl")

--- a/src/core.jl
+++ b/src/core.jl
@@ -17,11 +17,12 @@ end
 """
     train!(model::MLJFlux.MLJFluxModel, penalty, chain, optimiser, X, y)
 
-A private method.
+A private method that can be overloaded for custom models.
 
 Update the parameters of a Flux `chain`, where:
 
-- `(yhat, y) -> loss(yhat, y)` is the loss function
+- the loss function `(yhat, y) -> loss(yhat, y)` is inferred from the
+  `model`
 
 - `params -> penalty(params)` is a regularization penalty function
 
@@ -50,10 +51,10 @@ end
 """
     fit!(model::MLJFlux.MLJFluxModel, penalty, chain, optimiser, epochs, verbosity, X, y)
 
-A private method.
+A private method that can be overloaded for custom models.
 
 Optimize a Flux model `chain`, where `(yhat, y) -> loss(yhat, y)` is
-the loss, and `parameters -> penalty(parameters)` is the
+the loss function inferred from the `model`, and `parameters -> penalty(parameters)` is the
 regularization penalty function.
 
 Here `chain` is a `Flux.Chain` object, or other Flux model such that

--- a/src/core.jl
+++ b/src/core.jl
@@ -15,7 +15,7 @@ end
 (::Mover{<:CUDALibs})(data) = Flux.gpu(data)
 
 """
-    train!(loss, penalty, chain, optimiser, X, y)
+    train!(model::MLJFlux.MLJFluxModel, penalty, chain, optimiser, X, y)
 
 A private method.
 
@@ -29,25 +29,26 @@ Update the parameters of a Flux `chain`, where:
   in the [`MLJFlux.fit!`](@ref) document string.
 
 """
-function train!(loss, penalty, chain, optimiser, X, y)
+function train!(model::MLJFlux.MLJFluxModel, penalty, chain, optimiser, X, y)
+    loss = model.loss
     n_batches = length(y)
     training_loss = zero(Float32)
     for i in 1:n_batches
         parameters = Flux.params(chain)
         gs = Flux.gradient(parameters) do
             yhat = chain(X[i])
-            batch_loss = loss(yhat, y[i]) + penalty(parameters)/n_batches
+            batch_loss = loss(yhat, y[i]) + penalty(parameters) / n_batches
             training_loss += batch_loss
             return batch_loss
         end
         Flux.update!(optimiser, parameters, gs)
     end
-    return training_loss/n_batches
+    return training_loss / n_batches
 end
 
 
 """
-    fit!(loss, penalty, chain, optimiser, epochs, verbosity, X, y)
+    fit!(model::MLJFlux.MLJFluxModel, penalty, chain, optimiser, epochs, verbosity, X, y)
 
 A private method.
 
@@ -84,11 +85,13 @@ of `chain` and `history` is a vector of penalized losses - one initial
 loss, and one loss per epoch.
 
 """
-function  fit!(loss, penalty, chain, optimiser, epochs, verbosity, X, y)
+function fit!(model::MLJFlux.MLJFluxModel, penalty, chain, optimiser, epochs, verbosity, X, y)
+
+    loss = model.loss
 
     # intitialize and start progress meter:
-    meter = Progress(epochs+1, dt=0, desc="Optimising neural net:",
-                     barglyphs=BarGlyphs("[=> ]"), barlen=25, color=:yellow)
+    meter = Progress(epochs + 1, dt=0, desc="Optimising neural net:",
+        barglyphs=BarGlyphs("[=> ]"), barlen=25, color=:yellow)
     verbosity != 1 || next!(meter)
 
     # initiate history:
@@ -96,11 +99,11 @@ function  fit!(loss, penalty, chain, optimiser, epochs, verbosity, X, y)
 
     parameters = Flux.params(chain)
     losses = (loss(chain(X[i]), y[i]) +
-              penalty(parameters)/n_batches for i in 1:n_batches)
+              penalty(parameters) / n_batches for i in 1:n_batches)
     history = [mean(losses),]
 
     for i in 1:epochs
-        current_loss = train!(loss, penalty, chain, optimiser, X, y)
+        current_loss = train!(model::MLJFlux.MLJFluxModel, penalty, chain, optimiser, X, y)
         verbosity < 2 ||
             @info "Loss is $(round(current_loss; sigdigits=4))"
         verbosity != 1 || next!(meter)
@@ -124,7 +127,7 @@ Returns `true` if `acceleration=CUDALibs()` option is unavailable, and
 false otherwise.
 
 """
-gpu_isdead() = Flux.gpu([1.0, ]) isa Array
+gpu_isdead() = Flux.gpu([1.0,]) isa Array
 
 """
     nrows(X)
@@ -157,14 +160,14 @@ reformat(X, ::Type{<:GrayImage}) =
 
 function reformat(X, ::Type{<:AbstractVector{<:GrayImage}})
     ret = zeros(Float32, size(first(X))..., 1, length(X))
-    for idx=1:size(ret, 4)
+    for idx = 1:size(ret, 4)
         ret[:, :, :, idx] .= reformat(X[idx])
     end
     return ret
 end
 
 function reformat(X, ::Type{<:ColorImage})
-    ret = zeros(Float32, size(X)... , 3)
+    ret = zeros(Float32, size(X)..., 3)
     for w = 1:size(X)[1]
         for h = 1:size(X)[2]
             ret[w, h, :] .= Float32.([X[w, h].r, X[w, h].g, X[w, h].b])
@@ -175,7 +178,7 @@ end
 
 function reformat(X, ::Type{<:AbstractVector{<:ColorImage}})
     ret = zeros(Float32, size(first(X))..., 3, length(X))
-    for idx=1:size(ret, 4)
+    for idx = 1:size(ret, 4)
         ret[:, :, :, idx] .= reformat(X[idx])
     end
     return ret
@@ -207,7 +210,7 @@ _get(Xmatrix::AbstractMatrix, b) = Xmatrix[:, b]
 _get(y::AbstractVector, b) = y[b]
 
 # each element in X is a single image of size (w, h, c)
-_get(X::AbstractArray{<:Any, 4}, b) = X[:, :, :, b]
+_get(X::AbstractArray{<:Any,4}, b) = X[:, :, :, b]
 
 
 """

--- a/src/mlj_model_interface.jl
+++ b/src/mlj_model_interface.jl
@@ -74,7 +74,7 @@ function MLJModelInterface.fit(model::MLJFluxModel,
 
     optimiser = deepcopy(model.optimiser)
 
-    chain, history = fit!(model.loss,
+    chain, history = fit!(model,
                           penalty,
                           chain,
                           optimiser,
@@ -137,7 +137,7 @@ function MLJModelInterface.update(model::MLJFluxModel,
         optimiser = deepcopy(model.optimiser)
     end
 
-    chain, history = fit!(model.loss,
+    chain, history = fit!(model,
                           penalty,
                           chain,
                           optimiser,

--- a/test/core.jl
+++ b/test/core.jl
@@ -109,7 +109,7 @@ epochs = 10
 
     Random.seed!(123)
     penalty = MLJFlux.Penalty(model)
-    _chain_yes_drop, history = MLJFlux.fit!(model.loss,
+    _chain_yes_drop, history = MLJFlux.fit!(model,
                                             penalty,
                                             chain_yes_drop,
                                             Flux.Optimise.Adam(0.001),
@@ -121,7 +121,7 @@ epochs = 10
 
     Random.seed!(123)
     penalty = MLJFlux.Penalty(model)
-    _chain_no_drop, history = MLJFlux.fit!(model.loss,
+    _chain_no_drop, history = MLJFlux.fit!(model,
                                            penalty,
                                            chain_no_drop,
                                            Flux.Optimise.Adam(0.001),


### PR DESCRIPTION
**Suggestion**

This adds a minor change to two important private methods: `train!` and `fit!`. Dispatching these on the `model::MLJFlux.MLJFluxModel` would allow users/developers to implement custom training loops without changing the default behaviour for default models (`NeuralNetworkRegressor`, `NeuralNetworkClassiefier`, ...). 

**Example**

I'm using this branch in the development version of a new package I'm working on: [`JointEnergyModels.jl`](https://github.com/JuliaTrustworthyAI/JointEnergyModels.jl). That package is tailored to `Flux.jl` but the minimal changes suggested here have made it possible to make it compatible with `MLJFlux.jl` without much hassle:

- Add a `JointEnergyClassifier` constructor that subtypes `MLJFlux.MLJFluxProbabilistic` and mostly inherits methods and fields from the `NeuralNetworkClassifier` through [composition](https://discourse.julialang.org/t/composition-and-inheritance-the-julian-way/11231).
- Add a custom `fit!` method for `JointEnergyClassifier`.

Details can be found in [`src/mlj_flux.jl`](https://github.com/JuliaTrustworthyAI/JointEnergyModels.jl/blob/main/src/mlj_flux.jl). 

Similarly this could help with adding support for adversarial training, for example. 

**Alternatives?**

Since the methods are currently indicated as "private", I'm not sure this approach is aligned with the design you have in mind. If you'd rather not go down this route, do you have any suggestions for alternatives?

### PR Checklist

- [x] Tests are added
- [ ] Documentation, if applicable
