### PR TITLE
Fix target scitype for multitarget regressor

### DIFF
--- a/src/regressor.jl
+++ b/src/regressor.jl
@@ -68,5 +68,5 @@ end
 
 MLJModelInterface.metadata_model(MultitargetNeuralNetworkRegressor,
     input=Union{AbstractMatrix{Continuous},Table(Continuous)},
-    target=Table(Continuous),
+    target=Union{AbstractMatrix{Continuous}, Table(Continuous)},
     path="MLJFlux.MultitargetNeuralNetworkRegressor")


### PR DESCRIPTION
The PR #219 allows matrices but the target  scitype was not updated. 