### PR TITLE
Off-by-one error in clean! method

### DIFF
--- a/src/mlj_model_interface.jl
+++ b/src/mlj_model_interface.jl
@@ -22,8 +22,8 @@ function MLJModelInterface.clean!(model::MLJFluxModel)
         warning *= "Need `epochs ≥ 0`. Resetting `epochs = 10`. "
         model.epochs = 10
     end
-    if model.batch_size < 0
-        warning *= "Need `batch_size ≥ 0`. Resetting `batch_size = 1`. "
+    if model.batch_size <= 0
+        warning *= "Need `batch_size > 0`. Resetting `batch_size = 1`. "
         model.batch_size = 1
     end
     if model.acceleration isa CUDALibs && gpu_isdead()

--- a/test/mlj_model_interface.jl
+++ b/test/mlj_model_interface.jl
@@ -25,7 +25,7 @@ end
     @test model.epochs == 10
 
     model = @test_logs (:warn, r"`batch_size") begin
-        ModelType(batch_size = -1)
+        ModelType(batch_size = 0)
     end
     @test model.batch_size == 1
 


### PR DESCRIPTION
### Bug description
When a model is constructed with batch_size=0 it passes the [clean!](https://github.com/FluxML/MLJFlux.jl/blob/bf410e18b8ac019db740942ef3976edbae6d56df/src/mlj_model_interface.jl#L25) method without warning and batch_size remains at value 0. However the [fit!](https://github.com/FluxML/MLJFlux.jl/blob/bf410e18b8ac019db740942ef3976edbae6d56df/src/mlj_model_interface.jl#L65) method attempts to [collate](https://github.com/FluxML/MLJFlux.jl/blob/bf410e18b8ac019db740942ef3976edbae6d56df/src/core.jl#L231) the data into batches which is not possible due to the Julia [partition](https://github.com/JuliaLang/julia/blob/147bdf428cd14c979202678127d1618e425912d6/base/iterators.jl#L1264) method (please find the method below) called in collate throwing an error when attempting to set n as 0.
```julia
function partition(c, n::Integer)
    n < 1 && throw(ArgumentError("cannot create partitions of length $n"))
    return PartitionIterator(c, Int(n))
end
```
I am not entirely certain if 0 is meant to stand for no batching or if un-batched training is not an intended feature, but currently I am assuming it is the latter due to the way training is done, with un-batched training basically not being possible. Therefore I assume this is an off-by-one error and have made the clean! method reject batch_size=0 along with everything below that.

### PR Checklist

- [x] Tests are added