### PR TITLE
automatically convert input matrix to Float32

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -33,6 +33,7 @@ julia = "1.9"
 [extras]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
@@ -42,4 +43,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 cuDNN = "02a925ec-e4fe-4b08-9a7e-0d78e3d38ccd"
 
 [targets]
-test = ["CUDA", "cuDNN", "LinearAlgebra", "MLJBase", "Random", "StableRNGs", "StatisticalMeasures", "StatsBase", "Test"]
+test = ["CUDA", "cuDNN", "LinearAlgebra", "Logging", "MLJBase", "Random", "StableRNGs", "StatisticalMeasures", "StatsBase", "Test"]

--- a/src/core.jl
+++ b/src/core.jl
@@ -281,8 +281,8 @@ function collate(model::NeuralNetworkBinaryClassifier, X, y, verbosity)
     return [_get(Xmatrix, b) for b in row_batches], [_get(yvec, b) for b in row_batches]
 end
 
-_f32(x::AbstractMatrix{Float32}, verbosity) = x
-function _f32(x::AbstractMatrix, verbosity)
+_f32(x::AbstractArray{Float32}, verbosity) = x
+function _f32(x::AbstractArray, verbosity)
     verbosity > 0 && @info "MLJFlux: converting input data to Float32"
     return Float32.(x)
 end

--- a/src/core.jl
+++ b/src/core.jl
@@ -268,15 +268,22 @@ input `X` and target `y` in the form required by
 by `model.batch_size`.)
 
 """
-function collate(model, X, y)
+function collate(model, X, y, verbosity)
     row_batches = Base.Iterators.partition(1:nrows(y), model.batch_size)
-    Xmatrix = reformat(X)
+    Xmatrix = _f32(reformat(X), verbosity)
     ymatrix = reformat(y)
     return [_get(Xmatrix, b) for b in row_batches], [_get(ymatrix, b) for b in row_batches]
 end
-function collate(model::NeuralNetworkBinaryClassifier, X, y)
+function collate(model::NeuralNetworkBinaryClassifier, X, y, verbosity)
     row_batches = Base.Iterators.partition(1:nrows(y), model.batch_size)
-    Xmatrix = reformat(X)
+    Xmatrix = _f32(reformat(X), verbosity)
     yvec = (y .== classes(y)[2])' # convert to boolean
     return [_get(Xmatrix, b) for b in row_batches], [_get(yvec, b) for b in row_batches]
 end
+
+_f32(x::AbstractMatrix{Float32}, verbosity) = x
+function _f32(x::AbstractMatrix, verbosity)
+    verbosity > 0 && @info "MLJFlux: converting input data to Float32"
+    return Float32.(x)
+end
+

--- a/src/mlj_model_interface.jl
+++ b/src/mlj_model_interface.jl
@@ -107,7 +107,7 @@ function MLJModelInterface.fit(model::MLJFluxModel,
         rethrow()
     end
 
-    data = move.(collate(model, X, y))
+    data = move.(collate(model, X, y, verbosity))
     x = data[1][1]
 
     try

--- a/src/mlj_model_interface.jl
+++ b/src/mlj_model_interface.jl
@@ -175,7 +175,7 @@ function MLJModelInterface.update(model::MLJFluxModel,
         rng = true_rng(model)
         chain = build(model, rng, shape) |> move
         # reset `optimiser_state`:
-        data = move.(collate(model, X, y))
+        data = move.(collate(model, X, y, verbosity))
         nbatches = length(data[2])
         regularized_optimiser = MLJFlux.regularized_optimiser(model, nbatches)
         optimiser_state = Optimisers.setup(regularized_optimiser, chain)

--- a/test/mlj_model_interface.jl
+++ b/test/mlj_model_interface.jl
@@ -94,7 +94,7 @@ end
         # (2) manually train for one epoch explicitly adding a loss penalty:
         chain = MLJFlux.build(builder, StableRNG(123), 3, 1);
         penalty = Penalizer(lambda, alpha); # defined in test_utils.jl
-        X, y = MLJFlux.collate(model, Xuser, yuser);
+        X, y = MLJFlux.collate(model, Xuser, yuser, 0);
         loss = model.loss;
         n_batches = div(nobservations, batch_size)
         optimiser_state = Optimisers.setup(optimiser, chain);

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,7 @@ using StableRNGs
 using CUDA, cuDNN
 import StatisticalMeasures
 import Optimisers
+import Logging
 
 using ComputationalResources
 using ComputationalResources: CPU1, CUDALibs


### PR DESCRIPTION
This follows up on https://github.com/JuliaAI/MLJModels.jl/issues/565 and just adds a tiny step that automatically converts input to `Float32` before passing it to Flux.

I can't see why anyone would ever not want this, as the eltype of any neural net generated through MLJFlux will always be `Float32`, and any other input type will be converted to `Float32` anyways, but with a much bigger computational cost. So I didn't build in an option to disable this behaviour.

The reason to have this in MLJFlux in particular is that other machines such as `MLJModels.OneHotEncoder` output Float64 types.

I didn't look into https://github.com/FluxML/MLJFlux.jl/pull/267 in detail and it might make this redundant in some cases, but maybe not in all? 