### PR TITLE
Diagnostic PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
       matrix:
         version:
           - '1.9'
+          - '1.10' # new lts release
           - '1'
         os:
           - ubuntu-latest

--- a/src/MLJFlux.jl
+++ b/src/MLJFlux.jl
@@ -1,4 +1,4 @@
-module MLJFlux
+module MLJFlux 
 
 export CUDALibs, CPU1
 import Flux


### PR DESCRIPTION
At #278  it is reported that tests fail in some way orthogonal to the PR. 

The current PR makes only a whitespace change to dev, to verify the failing state of dev.

**edit** It also adds testing for 1.10 which has now been supplanted by 1.11 (a possible trip for the previously unreported fail)